### PR TITLE
Getting some basic path generation and visualization working

### DIFF
--- a/include/ManualRewardMap.h
+++ b/include/ManualRewardMap.h
@@ -7,6 +7,10 @@ struct site_obj
 {
     std::pair<double,double> coordinates;
     double reward_val;
+
+    bool operator < (const site_obj input_site) const {
+        return (reward_val<input_site.reward_val);
+    }
 };
 
 
@@ -91,7 +95,14 @@ class ManualRewardMap
 
         void draw_map();
 
+        void draw_map_with_paths(const std::vector<site_obj>);
+
+        std::pair<std::vector<site_obj>,double>  generate_paths_descending_priority();
 
 
+        std::pair<std::vector<site_obj>,double> generate_paths_distance_weighted_NN(const double distance_weight);
+
+        void plot_NN_total_distance_swept_distance_weight(double weight_increment,size_t num_weight_increments);
+        
 };
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,0 +1,10 @@
+#include <iostream>
+#include "ManualRewardMap.h"
+
+double weighted_cost_function(double input_site_reward_function, double input_distance_to_site, double input_distance_weight);
+
+double distance(std::pair<double,double> input_coords_1, std::pair<double,double> input_coords_2);
+
+double calc_cost_function_from_position_to_site(std::pair<double,double> current_position,site_obj target_site, double input_distance_weight);
+
+double calculate_total_distance_from_sequence(std::pair<double,double> input_starting_position, std::vector<site_obj> input_site_sequence);

--- a/src/ManualRewardMap.cpp
+++ b/src/ManualRewardMap.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
-#include "ManualRewardMap.h"
 #include <fstream>
+#include "utils.h"
 
 void ManualRewardMap::generate_map(){
     map_.resize(map_side_length_y_,map_side_length_x_);
@@ -125,18 +125,155 @@ void ManualRewardMap::draw_map(){
     if (gnuplot_pipe){
         //formatting
         fprintf(gnuplot_pipe, "set view map\n");
-        fprintf(gnuplot_pipe, "set title 'Reward Map'\n");
+        fprintf(gnuplot_pipe, "set title 'Reward Map' font 'Arial,16'\n");
         fprintf(gnuplot_pipe, "set xrange [%f:%f]\n",min_x_,max_x_);
         fprintf(gnuplot_pipe, "set yrange [%f:%f]\n",min_y_,max_y_);
+        fprintf(gnuplot_pipe, "set cblabel 'Reward Function' font 'Arial,14'\n");
+        fprintf(gnuplot_pipe, "set tics font 'Helvetica,14'\n");
+        fprintf(gnuplot_pipe, "set palette defined (0 'white', %f 'forest-green')\n",max_reward_val_);
+        fprintf(gnuplot_pipe, "plot 'map_data.dat' using 2:1:3 with image\n");
+        fprintf(gnuplot_pipe, "exit \n");
+        pclose(gnuplot_pipe);
+
+    }
+
+}
+
+
+
+void ManualRewardMap::draw_map_with_paths(const std::vector<site_obj> input_sorted_site_list){
+
+    //first make the data file
+    //want to scale the x and y axes to be in coordinate form instead of indices of a matrix 
+    size_t const row_count = static_cast<size_t>(map_.rows());
+    size_t const col_count = static_cast<size_t>(map_.cols());
+    double discrete_movement_x=(max_x_-min_x_)/(map_side_length_x_-1);
+    double discrete_movement_y=(max_y_-min_y_)/(map_side_length_y_-1);
+
+
+    std::ofstream output_file("map_data.dat");
+    if (output_file.is_open()){
+        for (size_t row_index=0;row_index<row_count;row_index++){
+            for (size_t col_index=0;col_index<col_count;col_index++)
+                output_file << min_x_+row_index*discrete_movement_x <<" "<< min_y_+col_index*discrete_movement_y <<" "<< map_(row_index,col_index) << "\n";
+        }
+        
+        output_file.close();
+    }
+    if (output_file.is_open()){
+        std::cout << "File is unexpectedly still open\n";
+    }
+    //using Gnuplot
+    FILE *gnuplot_pipe = popen("gnuplot -persist", "w");
+
+    if (gnuplot_pipe){
+        //formatting
+        fprintf(gnuplot_pipe, "set view map\n");
+        fprintf(gnuplot_pipe, "set title 'Reward Map' font 'Arial,16'\n");
+        fprintf(gnuplot_pipe, "set xrange [%f:%f]\n",min_x_,max_x_);
+        fprintf(gnuplot_pipe, "set yrange [%f:%f]\n",min_y_,max_y_);
+        fprintf(gnuplot_pipe, "set cblabel 'Reward Function' font 'Arial,14' offset 1\n");
+        fprintf(gnuplot_pipe, "set tics font 'Helvetica,14'\n");
 
         fprintf(gnuplot_pipe, "set palette defined (0 'white', %f 'forest-green')\n",max_reward_val_);
 
 
+        //the input_sorted_site_list should list the sites in the order to visit them
+
+        if (input_sorted_site_list.size()>1){
+            double next_site_x_coord=input_sorted_site_list.at(0).coordinates.first;
+            double next_site_y_coord=input_sorted_site_list.at(0).coordinates.second;
+            fprintf(gnuplot_pipe, "set arrow from %f,%f to %f,%f,1 filled front\n",starting_position_.first,starting_position_.second,next_site_x_coord,next_site_y_coord);
+            for (int arrow_ind=1;arrow_ind<input_sorted_site_list.size();arrow_ind++){
+                double previous_site_x_coord=input_sorted_site_list.at(arrow_ind-1).coordinates.first;
+                double previous_site_y_coord=input_sorted_site_list.at(arrow_ind-1).coordinates.second;
+                next_site_x_coord=input_sorted_site_list.at(arrow_ind).coordinates.first;
+                next_site_y_coord=input_sorted_site_list.at(arrow_ind).coordinates.second;
+                fprintf(gnuplot_pipe, "set arrow from %f,%f to %f,%f,%d filled front\n",previous_site_x_coord,previous_site_y_coord,next_site_x_coord,next_site_y_coord,arrow_ind);
+            }
+        }
+
         fprintf(gnuplot_pipe, "plot 'map_data.dat' using 2:1:3 with image\n");
-        
         fprintf(gnuplot_pipe, "exit \n");
         pclose(gnuplot_pipe);
 
+    }
+
+}
+
+
+std::pair<std::vector<site_obj>,double> ManualRewardMap::generate_paths_descending_priority(){
+
+    std::vector<site_obj> sorted_list_of_sites=list_of_sites_;
+    std::sort(sorted_list_of_sites.begin(),sorted_list_of_sites.end());
+    std::reverse(sorted_list_of_sites.begin(),sorted_list_of_sites.end());
+
+    double total_distance=calculate_total_distance_from_sequence(starting_position_,sorted_list_of_sites);
+    std::pair<std::vector<site_obj>,double> output_pair;
+    output_pair.first=sorted_list_of_sites;
+    output_pair.second=total_distance;
+    return output_pair;
+}
+
+std::pair<std::vector<site_obj>,double> ManualRewardMap::generate_paths_distance_weighted_NN(const double distance_weight){
+    //Nearest-neighbor algorithm taking into account both distance and site reward vals in the spirit of, e.g., https://en.wikipedia.org/wiki/Nearest_neighbour_algorithm
+
+    std::vector<site_obj> visited_sites={};
+    std::vector<site_obj> unvisited_sites=list_of_sites_;
+
+    std::pair<double,double> current_coords=starting_position_;
+
+    while (unvisited_sites.size()>0){
+        double lowest_cost=INFINITY;
+        size_t best_site_index={list_of_sites_.size()}; //should throw out of range error if this never gets changed
+        //find the site with the lowest total "cost" associated with visiting it from the current position, taking into account distance and reward function
+        for (size_t site_ind=0;site_ind<unvisited_sites.size();site_ind++){
+            site_obj site=unvisited_sites.at(site_ind);
+            double calculated_cost=calc_cost_function_from_position_to_site(current_coords,site,distance_weight);
+            if (calculated_cost<lowest_cost){
+                lowest_cost=calculated_cost;
+                best_site_index=site_ind;
+            }
+        }
+        site_obj visited_site=unvisited_sites.at(best_site_index);
+        current_coords=visited_site.coordinates;
+        visited_sites.push_back(visited_site);
+        unvisited_sites.erase(unvisited_sites.begin()+best_site_index);
+    }
+
+
+    double total_distance=calculate_total_distance_from_sequence(starting_position_,visited_sites);
+    std::pair<std::vector<site_obj>,double> output_pair;
+    output_pair.first=visited_sites;
+    output_pair.second=total_distance;
+    return output_pair;
+}
+
+
+
+void ManualRewardMap::plot_NN_total_distance_swept_distance_weight(double weight_increment,size_t num_weight_increments){
+
+    //using Gnuplot
+    FILE *gnuplot_pipe = popen("gnuplot -persist", "w");
+
+    if (gnuplot_pipe){
+        //formatting
+        fprintf(gnuplot_pipe, "set view map\n");
+        fprintf(gnuplot_pipe, "set title 'Total Distance' font 'Arial,16'\n");
+        fprintf(gnuplot_pipe, "set xlabel 'Distance Weight' font 'Arial,16'\n");
+
+        fprintf(gnuplot_pipe, "plot '-' with lines notitle\n");
+
+        for (size_t index=0;index<num_weight_increments;index++){
+            double distance_weight=weight_increment*index;
+            std::pair<std::vector<site_obj>,double> output_pair=generate_paths_distance_weighted_NN(distance_weight);
+            double total_distance=output_pair.second;
+            fprintf(gnuplot_pipe, "%f %f\n",distance_weight,total_distance);
+        }
+        fprintf(gnuplot_pipe, "e \n");
+
+        fprintf(gnuplot_pipe, "exit \n");
+        pclose(gnuplot_pipe);
     }
 
 }

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -6,10 +6,16 @@ int main(){
     std::pair<double,double> site_1_coords={0.8,0.8}; //(x,y)
     std::pair<double,double> site_2_coords={0.1,0.9};
     std::pair<double,double> site_3_coords={1.5,0.1};
+    std::pair<double,double> site_4_coords={1.0,0.3};
+    std::pair<double,double> site_5_coords={0.2,1.8};
+    std::pair<double,double> site_6_coords={1.7,1.9};
 
     double site_1_reward_val=0.8;
     double site_2_reward_val=0.2;
     double site_3_reward_val=0.4;
+    double site_4_reward_val=0.9;
+    double site_5_reward_val=0.71;
+    double site_6_reward_val=0.99;
 
     site_obj manual_site_1;
     manual_site_1.coordinates=site_1_coords;
@@ -23,7 +29,19 @@ int main(){
     manual_site_3.coordinates=site_3_coords;
     manual_site_3.reward_val=site_3_reward_val;
 
-    std::vector<site_obj> list_of_sites={manual_site_1,manual_site_2,manual_site_3};
+    site_obj manual_site_4;
+    manual_site_4.coordinates=site_4_coords;
+    manual_site_4.reward_val=site_4_reward_val;
+
+    site_obj manual_site_5;
+    manual_site_5.coordinates=site_5_coords;
+    manual_site_5.reward_val=site_5_reward_val;
+
+    site_obj manual_site_6;
+    manual_site_6.coordinates=site_6_coords;
+    manual_site_6.reward_val=site_6_reward_val;
+
+    std::vector<site_obj> list_of_sites={manual_site_1,manual_site_2,manual_site_3,manual_site_4,manual_site_5,manual_site_6};
 
     std::pair<double,double> starting_position={0,0};
 
@@ -37,14 +55,44 @@ int main(){
     manual_reward_map.set_initial_position(starting_position);
 
     manual_reward_map.generate_map();
-    manual_reward_map.draw_map();
 
-    // manual_reward_map.generate_paths();
+    // manual_reward_map.draw_map();
 
-    // manual_reward_map.plot_paths();
+    std::pair<std::vector<site_obj>,double>  paths_and_distance_1=manual_reward_map.generate_paths_descending_priority();
+    std::vector<site_obj> paths_1=paths_and_distance_1.first;
+    double distance_1=paths_and_distance_1.second;
+    manual_reward_map.draw_map_with_paths(paths_1);
+    std::cout << "Total distance of descending priority method: " << distance_1 << "\n";
 
 
+    double distance_weight_1=0.01;
+    std::pair<std::vector<site_obj>,double>  paths_and_distance_2=manual_reward_map.generate_paths_distance_weighted_NN(distance_weight_1);
+    std::vector<site_obj> paths_2=paths_and_distance_2.first;
+    double distance_2=paths_and_distance_2.second;
+    manual_reward_map.draw_map_with_paths(paths_2);
+    std::cout << "Total distance of NN method with distance weight = " << distance_weight_1 << ": " << distance_2 << "\n";
 
+
+    double distance_weight_2=1;
+    std::pair<std::vector<site_obj>,double>  paths_and_distance_3=manual_reward_map.generate_paths_distance_weighted_NN(distance_weight_2);
+    std::vector<site_obj> paths_3=paths_and_distance_3.first;
+    double distance_3=paths_and_distance_3.second;
+    manual_reward_map.draw_map_with_paths(paths_3);
+    std::cout << "Total distance of NN method with distance weight = " << distance_weight_2 << ": " << distance_3 << "\n";
+
+
+    double distance_weight_3=100;
+    std::pair<std::vector<site_obj>,double>  paths_and_distance_4=manual_reward_map.generate_paths_distance_weighted_NN(distance_weight_3);
+    std::vector<site_obj> paths_4=paths_and_distance_4.first;
+    double distance_4=paths_and_distance_4.second;
+    manual_reward_map.draw_map_with_paths(paths_4);
+    std::cout << "Total distance of NN method with distance weight = " << distance_weight_3 << ": " << distance_4 << "\n";
+
+
+    //Let's try sweeping this distance_weight and see if there's a noticeable minimum of the total distance
+    double weight_increment=0.001;
+    size_t num_weight_increments=6000;
+    manual_reward_map.plot_NN_total_distance_swept_distance_weight(weight_increment,num_weight_increments);
 
 
     return 0;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,37 @@
+#include <iostream>
+#include "ManualRewardMap.h"
+
+double weighted_cost_function(double input_site_reward_function_val, double input_distance_to_site, double input_distance_weight){
+    return (-input_site_reward_function_val + input_distance_to_site*input_distance_weight);
+}
+
+double distance(std::pair<double,double> input_coords_1, std::pair<double,double> input_coords_2){
+    //Euclidean distance between two coordinate pairs
+    return std::sqrt(std::pow(input_coords_2.first-input_coords_1.first,2) + std::pow(input_coords_2.second-input_coords_1.second,2));
+}
+
+double calc_cost_function_from_position_to_site(std::pair<double,double> current_position,site_obj target_site, double input_distance_weight){
+
+    double calculated_distance=distance(current_position,target_site.coordinates);
+    double total_cost=weighted_cost_function(target_site.reward_val,calculated_distance,input_distance_weight);
+
+    return total_cost;
+
+}
+
+double calculate_total_distance_from_sequence(std::pair<double,double> input_starting_position, std::vector<site_obj> input_site_sequence){
+    if (input_site_sequence.size()==0){
+        return 0;
+    }
+    //first site
+    double calculated_distance=distance(input_starting_position,input_site_sequence.at(0).coordinates);
+    double total_distance=calculated_distance;
+
+    std::pair<double,double> current_position=input_site_sequence.at(0).coordinates;
+    for (size_t site_ind=1;site_ind<input_site_sequence.size();site_ind++){
+        calculated_distance=distance(current_position,input_site_sequence.at(site_ind).coordinates);
+        total_distance+=calculated_distance;
+    }
+
+    return total_distance;
+}


### PR DESCRIPTION
# Context

This is a first commit implementing the originally desired functionality of generating and displaying a path between all the identified sites of interest. Improvements can still likely be made in formatting and how these paths are generated.

# Changes

Currently implementing 2 approaches to path generation between sites of interest: 

1) Strictly going in descending order of reward value of the sites 

2) A nearest-neighbor-type approach that allows an input weight on distance between coordinates to make distances considered in the pathing decisions. Taking this limit to 0 should recover the results of the first method described above, and taking the large limit on this weight should recover the result of ignoring the reward values of the sites and treating it as a Traveling Salesman Problem with a nearest-neighbor approach.

Also added functionality to plot total distance as a function of this distance weight.

Added various supporting utility functions to calculate, e.g., distances or costs.
