### PR TITLE
Adding random map generation and processing workflow for randomly-generated maps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,12 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(Eigen googletest)
 
-add_executable(run src/core.cpp src/utils.cpp src/ManualRewardMap.cpp)
+add_executable(run_manual_map_demo src/manual_map_demo.cpp src/utils.cpp src/ManualRewardMap.cpp)
+add_executable(run_random_map_demo src/random_map_demo.cpp src/utils.cpp src/RandomRewardMap.cpp)
+
 add_executable(unit_tests tests/unit_tests.cpp src/utils.cpp src/ManualRewardMap.cpp)
 
-target_link_libraries(run PRIVATE Eigen3::Eigen)
+target_link_libraries(run_manual_map_demo PRIVATE Eigen3::Eigen)
+target_link_libraries(run_random_map_demo PRIVATE Eigen3::Eigen)
+
 target_link_libraries(unit_tests PRIVATE Eigen3::Eigen gtest_main)

--- a/include/ManualRewardMap.h
+++ b/include/ManualRewardMap.h
@@ -1,18 +1,8 @@
 #include <iostream>
 #include <Eigen/Dense>
+#include "utils.h"
 
 using Eigen::MatrixXd;
-
-struct site_obj
-{
-    std::pair<double,double> coordinates;
-    double reward_val;
-
-    bool operator < (const site_obj input_site) const {
-        return (reward_val<input_site.reward_val);
-    }
-};
-
 
 class ManualRewardMap
 {

--- a/include/RandomRewardMap.h
+++ b/include/RandomRewardMap.h
@@ -1,0 +1,82 @@
+#include <iostream>
+#include <Eigen/Dense>
+#include <random>
+#include "utils.h"
+
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
+
+
+class RandomRewardMap
+{
+    private:
+
+
+        std::vector<site_obj> list_of_sites_={};
+
+        std::pair<size_t,size_t> coords_to_map_indices(std::pair<double,double> input_coords);
+    public:
+        std::pair<double,double> starting_position_;
+        double min_x_={0};
+        double max_x_={0};
+        double min_y_={0};
+        double max_y_={0};
+        double reward_range_min_={0};
+        double reward_range_max_={1};
+
+        size_t map_side_length_x_={100};
+        size_t map_side_length_y_={100};
+
+        MatrixXd map_;
+
+
+        RandomRewardMap(double map_side_length_x,double map_side_length_y,double min_x,double max_x,double min_y, double max_y,double reward_range_min, double reward_range_max){
+            map_side_length_x_=map_side_length_x;
+            map_side_length_y_=map_side_length_y;
+            min_x_=min_x;
+            min_y_=min_y;
+            max_x_=max_x;
+            max_y_=max_y;
+            reward_range_min_=reward_range_min;
+            reward_range_max_=reward_range_max;
+            starting_position_.first=0;
+            starting_position_.second=0;
+
+            std::random_device test_random_device;
+            std::mt19937 engine(test_random_device());
+            std::uniform_real_distribution<> reward_val_distribution(reward_range_min_,reward_range_max_);
+
+
+            map_=MatrixXd::Random(map_side_length_y_,map_side_length_x_);
+            //rescale to desired range since by default Random generates floats between -1 and 1
+            map_*=((reward_range_max_-reward_range_min_)/2); //because initially has a range of 2 from going between -1 and 1
+
+            MatrixXd tmp_mat=MatrixXd::Constant(map_side_length_y_,map_side_length_x_,reward_range_min_+((reward_range_max_-reward_range_min_)/2));
+            map_+=tmp_mat;
+
+
+        }
+    
+
+        void set_initial_position(std::pair<double,double> input_position){
+            starting_position_=input_position;
+        }
+
+        void identify_potential_sites(int input_num_sites, double input_site_reward_val_threshold=0.5);
+        void identify_potential_sites(double input_site_reward_val_threshold=0.5);
+
+
+        void draw_map();
+
+        void draw_map_with_paths(const std::vector<site_obj>);
+
+        std::pair<std::vector<site_obj>,double> generate_paths_distance_weighted_NN(const double distance_weight);
+
+        void plot_NN_total_distance_swept_distance_weight(double weight_increment,size_t num_weight_increments);
+
+        std::vector<site_obj> get_list_of_sites(){
+            return list_of_sites_;
+        }
+
+};
+

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,5 +1,21 @@
+#ifndef UTILS_H
+#define UTILS_H
+
 #include <iostream>
-#include "ManualRewardMap.h"
+
+struct site_obj
+{
+    std::pair<double,double> coordinates;
+    double reward_val;
+
+    bool operator < (const site_obj input_site) const {
+        return (reward_val<input_site.reward_val);
+    }
+    bool operator == (const site_obj input_site) const {
+        return ((coordinates.first==input_site.coordinates.first)&&(coordinates.second==input_site.coordinates.second));
+    }
+};
+
 
 double weighted_cost_function(double input_site_reward_function, double input_distance_to_site, double input_distance_weight);
 
@@ -8,3 +24,5 @@ double distance(std::pair<double,double> input_coords_1, std::pair<double,double
 double calc_cost_function_from_position_to_site(std::pair<double,double> current_position,site_obj target_site, double input_distance_weight);
 
 double calculate_total_distance_from_sequence(std::pair<double,double> input_starting_position, std::vector<site_obj> input_site_sequence);
+
+#endif

--- a/include/utils.h
+++ b/include/utils.h
@@ -2,6 +2,7 @@
 #define UTILS_H
 
 #include <iostream>
+#include <vector>
 
 struct site_obj
 {

--- a/src/ManualRewardMap.cpp
+++ b/src/ManualRewardMap.cpp
@@ -1,10 +1,11 @@
 #include <iostream>
 #include <fstream>
+#include "ManualRewardMap.h"
 #include "utils.h"
 
 void ManualRewardMap::generate_map(){
     map_.resize(map_side_length_y_,map_side_length_x_);
-    map_.setZero(); //fill background with zeros
+    map_.setZero(); //Fill background with zeros
     //y then x because params are (rows, cols) and cols will give us width in x
 
     if (min_site_x_coord_<=min_x_){
@@ -21,7 +22,7 @@ void ManualRewardMap::generate_map(){
         max_y_=max_site_y_coord_+0.1;
     }
 
-    //now need to find the pixel (row_ind,col_ind) in the map that best approximates the (x,y) coordinates of a given site
+    //Now need to find the pixel (row_ind,col_ind) in the map that best approximates the (x,y) coordinates of a given site
     for (site_obj site : list_of_sites_){
         std::pair<double,double> site_position=site.coordinates;
         std::pair<size_t,size_t> closest_map_index_pair=coords_to_map_indices(site_position);
@@ -48,7 +49,7 @@ std::pair<size_t,size_t> ManualRewardMap::coords_to_map_indices(std::pair<double
         closest_col_index= map_side_length_y_-1;
     }
     
-    //first let's find the position in the map matrix (which column) corresponding to the closest approximation of the input x coordinate
+    //First let's find the position in the map matrix (which column) corresponding to the closest approximation of the input x coordinate
     for (size_t column_index=0;column_index<map_side_length_x_-1;column_index++){
         double current_map_x_val=min_x_+(discrete_movement_x*column_index);
         double next_map_x_val=min_x_+(discrete_movement_x*(column_index+1));
@@ -59,7 +60,7 @@ std::pair<size_t,size_t> ManualRewardMap::coords_to_map_indices(std::pair<double
         }
         else if ((current_map_x_val<input_x)&&(next_map_x_val>input_x)){
             if (input_x-current_map_x_val < next_map_x_val-input_x){
-                //closer to current column index
+                //Closer to current column index
                 closest_col_index=column_index;
                 break;
             }
@@ -70,7 +71,7 @@ std::pair<size_t,size_t> ManualRewardMap::coords_to_map_indices(std::pair<double
         }
     }
 
-    //now let's find the position in the map matrix (which row) corresponding to the closest approximation of the input y coordinate
+    //Now let's find the position in the map matrix (which row) corresponding to the closest approximation of the input y coordinate
     for (size_t row_index=0;row_index<map_side_length_y_-1;row_index++){
         double current_map_y_val=min_y_+(discrete_movement_y*row_index);
         double next_map_y_val=min_y_+(discrete_movement_y*(row_index+1));
@@ -81,7 +82,7 @@ std::pair<size_t,size_t> ManualRewardMap::coords_to_map_indices(std::pair<double
         }
         else if ((current_map_y_val<input_y)&&(next_map_y_val>input_y)){
             if (input_y-current_map_y_val < next_map_y_val-input_y){
-                //closer to current row index
+                //Closer to current row index
                 closest_row_index=row_index;
                 break;
             }
@@ -99,8 +100,8 @@ std::pair<size_t,size_t> ManualRewardMap::coords_to_map_indices(std::pair<double
 void ManualRewardMap::draw_map(){
 
 
-    //first make the data file
-    //want to scale the x and y axes to be in coordinate form instead of indices of a matrix 
+    //First make the data file
+    //Want to scale the x and y axes to be in coordinate form instead of indices of a matrix 
     size_t const row_count = static_cast<size_t>(map_.rows());
     size_t const col_count = static_cast<size_t>(map_.cols());
     double discrete_movement_x=(max_x_-min_x_)/(map_side_length_x_-1);
@@ -120,11 +121,11 @@ void ManualRewardMap::draw_map(){
     if (output_file.is_open()){
         std::cout << "File is unexpectedly still open\n";
     }
-    //using Gnuplot
+    //Using Gnuplot
     FILE *gnuplot_pipe = popen("gnuplot -persist", "w");
 
     if (gnuplot_pipe){
-        //formatting
+        //Formatting
         fprintf(gnuplot_pipe, "set view map\n");
         fprintf(gnuplot_pipe, "set title 'Reward Map' font 'Arial,16'\n");
         fprintf(gnuplot_pipe, "set xrange [%f:%f]\n",min_x_,max_x_);
@@ -144,8 +145,8 @@ void ManualRewardMap::draw_map(){
 
 void ManualRewardMap::draw_map_with_paths(const std::vector<site_obj> input_sorted_site_list){
 
-    //first make the data file
-    //want to scale the x and y axes to be in coordinate form instead of indices of a matrix 
+    //First make the data file
+    //Want to scale the x and y axes to be in coordinate form instead of indices of a matrix 
     size_t const row_count = static_cast<size_t>(map_.rows());
     size_t const col_count = static_cast<size_t>(map_.cols());
     double discrete_movement_x=(max_x_-min_x_)/(map_side_length_x_-1);
@@ -165,11 +166,11 @@ void ManualRewardMap::draw_map_with_paths(const std::vector<site_obj> input_sort
     if (output_file.is_open()){
         std::cout << "File is unexpectedly still open\n";
     }
-    //using Gnuplot
+    //Using Gnuplot
     FILE *gnuplot_pipe = popen("gnuplot -persist", "w");
 
     if (gnuplot_pipe){
-        //formatting
+        //Formatting
         fprintf(gnuplot_pipe, "set view map\n");
         fprintf(gnuplot_pipe, "set title 'Reward Map' font 'Arial,16'\n");
         fprintf(gnuplot_pipe, "set xrange [%f:%f]\n",min_x_,max_x_);
@@ -180,7 +181,7 @@ void ManualRewardMap::draw_map_with_paths(const std::vector<site_obj> input_sort
         fprintf(gnuplot_pipe, "set palette defined (0 'white', %f 'forest-green')\n",max_reward_val_);
 
 
-        //the input_sorted_site_list should list the sites in the order to visit them
+        //The input_sorted_site_list should list the sites in the order to visit them
 
         if (input_sorted_site_list.size()>1){
             double next_site_x_coord=input_sorted_site_list.at(0).coordinates.first;
@@ -228,7 +229,7 @@ std::pair<std::vector<site_obj>,double> ManualRewardMap::generate_paths_distance
     while (unvisited_sites.size()>0){
         double lowest_cost=INFINITY;
         size_t best_site_index={list_of_sites_.size()}; //should throw out of range error if this never gets changed
-        //find the site with the lowest total "cost" associated with visiting it from the current position, taking into account distance and reward function
+        //Find the site with the lowest total "cost" associated with visiting it from the current position, taking into account distance and reward function
         for (size_t site_ind=0;site_ind<unvisited_sites.size();site_ind++){
             site_obj site=unvisited_sites.at(site_ind);
             double calculated_cost=calc_cost_function_from_position_to_site(current_coords,site,distance_weight);
@@ -255,11 +256,11 @@ std::pair<std::vector<site_obj>,double> ManualRewardMap::generate_paths_distance
 
 void ManualRewardMap::plot_NN_total_distance_swept_distance_weight(double weight_increment,size_t num_weight_increments){
 
-    //using Gnuplot
+    //Using Gnuplot
     FILE *gnuplot_pipe = popen("gnuplot -persist", "w");
 
     if (gnuplot_pipe){
-        //formatting
+        //Formatting
         fprintf(gnuplot_pipe, "set view map\n");
         fprintf(gnuplot_pipe, "set title 'Total Distance' font 'Arial,16'\n");
         fprintf(gnuplot_pipe, "set xlabel 'Distance Weight' font 'Arial,16'\n");

--- a/src/RandomRewardMap.cpp
+++ b/src/RandomRewardMap.cpp
@@ -1,0 +1,258 @@
+#include <iostream>
+#include <fstream>
+#include "utils.h"
+#include "RandomRewardMap.h"
+
+
+void RandomRewardMap::identify_potential_sites(int input_desired_num_sites, double input_site_reward_val_threshold){
+    //Populates the list_of_sites_ with the <input_desired_num_sites> sites with the highest reward vals above the input threshold
+    std::vector<site_obj> output_list_of_sites={};
+
+    double min_observed_reward_val=reward_range_min_;
+    double max_observed_reward_val=reward_range_max_;
+
+    size_t const row_count = static_cast<size_t>(map_.rows());
+    size_t const col_count = static_cast<size_t>(map_.cols());
+    double discrete_movement_x=(max_x_-min_x_)/(map_side_length_x_-1);
+    double discrete_movement_y=(max_y_-min_y_)/(map_side_length_y_-1);
+
+    for (size_t row_ind=0; row_ind<map_side_length_y_;row_ind++){
+        for (size_t col_ind=0;col_ind<map_side_length_x_;col_ind++){
+            double reward_val=map_(row_ind,col_ind);
+            if (reward_val>max_observed_reward_val){
+                max_observed_reward_val=reward_val;
+            }
+            if (reward_val<min_observed_reward_val){
+                min_observed_reward_val=reward_val;
+            }
+            if (reward_val>=input_site_reward_val_threshold){
+                double x_coord=min_x_+(col_ind*discrete_movement_x);
+                double y_coord=min_y_+(row_ind*discrete_movement_y);
+                site_obj new_site;
+                new_site.coordinates.first=x_coord;
+                new_site.coordinates.second=y_coord;
+                new_site.reward_val=map_(row_ind,col_ind);
+                output_list_of_sites.push_back(new_site);
+            }
+        }
+    }
+
+    std::cout << "Max observed reward val after scaling: " << max_observed_reward_val << "\n";
+    std::cout << "Min observed reward val after scaling: " << min_observed_reward_val << "\n";
+
+
+    //Sort the list in descending order of reward val
+    std::sort(output_list_of_sites.begin(),output_list_of_sites.end());
+    std::reverse(output_list_of_sites.begin(),output_list_of_sites.end());
+    std::vector<site_obj> trimmed_site_list(output_list_of_sites.begin(),output_list_of_sites.begin()+input_desired_num_sites);
+    list_of_sites_=trimmed_site_list;
+    return;
+    return;
+}
+
+
+void RandomRewardMap::identify_potential_sites(double input_site_reward_val_threshold){
+    //If no input_num_sites is passed to the function, then populates list_of_sites_ with all sites with reward vals greater than or equal to threshold val
+    std::vector<site_obj> output_list_of_sites={};
+
+    size_t const row_count = static_cast<size_t>(map_.rows());
+    size_t const col_count = static_cast<size_t>(map_.cols());
+    double discrete_movement_x=(max_x_-min_x_)/(map_side_length_x_-1);
+    double discrete_movement_y=(max_y_-min_y_)/(map_side_length_y_-1);
+
+    for (size_t row_ind=0; row_ind<map_side_length_y_;row_ind++){
+        for (size_t col_ind=0;col_ind<map_side_length_x_;col_ind++){
+            if (map_(row_ind,col_ind)>=input_site_reward_val_threshold){
+                double x_coord=min_x_+(col_ind*discrete_movement_x);
+                double y_coord=min_y_+(row_ind*discrete_movement_y);
+                site_obj new_site;
+                new_site.coordinates.first=x_coord;
+                new_site.coordinates.second=y_coord;
+                new_site.reward_val=map_(row_ind,col_ind);
+                output_list_of_sites.push_back(new_site);
+            }
+        }
+    }
+
+    //Sort the list in descending order of reward val
+    std::sort(output_list_of_sites.begin(),output_list_of_sites.end());
+    std::reverse(output_list_of_sites.begin(),output_list_of_sites.end());
+
+    list_of_sites_=output_list_of_sites;
+    return;
+}
+
+
+void RandomRewardMap::draw_map(){
+
+
+    //First make the data file
+    //Want to scale the x and y axes to be in coordinate form instead of indices of a matrix 
+    size_t const row_count = static_cast<size_t>(map_.rows());
+    size_t const col_count = static_cast<size_t>(map_.cols());
+    double discrete_movement_x=(max_x_-min_x_)/(map_side_length_x_-1);
+    double discrete_movement_y=(max_y_-min_y_)/(map_side_length_y_-1);
+
+
+    std::ofstream output_file("map_data.dat");
+    if (output_file.is_open()){
+        for (size_t row_index=0;row_index<row_count;row_index++){
+            for (size_t col_index=0;col_index<col_count;col_index++){
+                output_file << min_x_+(col_index*discrete_movement_x) <<" "<< min_y_+(row_index*discrete_movement_y) <<" "<< map_(row_index,col_index) << "\n";
+            }
+        }
+        
+        output_file.close();
+    }
+    if (output_file.is_open()){
+        std::cout << "File is unexpectedly still open\n";
+    }
+    //using Gnuplot
+    FILE *gnuplot_pipe = popen("gnuplot -persist", "w");
+
+    if (gnuplot_pipe){
+        //formatting
+        fprintf(gnuplot_pipe, "set view map\n");
+        fprintf(gnuplot_pipe, "set title 'Reward Map' font 'Times,16'\n");
+        fprintf(gnuplot_pipe, "set xrange [%f:%f]\n",min_x_,max_x_);
+        fprintf(gnuplot_pipe, "set yrange [%f:%f]\n",min_y_,max_y_);
+        fprintf(gnuplot_pipe, "set cblabel 'Reward Function' font 'Times,14'\n");
+        fprintf(gnuplot_pipe, "set tics font 'Times,14'\n");
+        fprintf(gnuplot_pipe, "set palette defined (%f 'white', %f 'forest-green')\n",reward_range_min_,reward_range_max_);
+        fprintf(gnuplot_pipe, "plot 'map_data.dat' using 1:2:3 with image\n");
+        fprintf(gnuplot_pipe, "exit \n");
+        pclose(gnuplot_pipe);
+
+    }
+
+}
+
+
+
+
+std::pair<std::vector<site_obj>,double> RandomRewardMap::generate_paths_distance_weighted_NN(const double distance_weight){
+    //Nearest-neighbor algorithm taking into account both distance and site reward vals in the spirit of, e.g., https://en.wikipedia.org/wiki/Nearest_neighbour_algorithm
+
+    std::vector<site_obj> visited_sites={};
+    std::vector<site_obj> unvisited_sites=list_of_sites_;
+
+    std::pair<double,double> current_coords=starting_position_;
+
+    while (unvisited_sites.size()>0){
+        double lowest_cost=INFINITY;
+        size_t best_site_index={list_of_sites_.size()}; //should throw out of range error if this never gets changed
+        //Find the site with the lowest total "cost" associated with visiting it from the current position, taking into account distance and reward function
+        for (size_t site_ind=0;site_ind<unvisited_sites.size();site_ind++){
+            site_obj site=unvisited_sites.at(site_ind);
+            double calculated_cost=calc_cost_function_from_position_to_site(current_coords,site,distance_weight);
+            if (calculated_cost<lowest_cost){
+                lowest_cost=calculated_cost;
+                best_site_index=site_ind;
+            }
+        }
+        site_obj visited_site=unvisited_sites.at(best_site_index);
+        current_coords=visited_site.coordinates;
+        visited_sites.push_back(visited_site);
+        unvisited_sites.erase(unvisited_sites.begin()+best_site_index);
+    }
+
+
+    double total_distance=calculate_total_distance_from_sequence(starting_position_,visited_sites);
+    std::pair<std::vector<site_obj>,double> output_pair;
+    output_pair.first=visited_sites;
+    output_pair.second=total_distance;
+    return output_pair;
+}
+
+
+
+void RandomRewardMap::draw_map_with_paths(const std::vector<site_obj> input_sorted_site_list){
+
+    //First make the data file
+    //Want to scale the x and y axes to be in coordinate form instead of indices of a matrix 
+    size_t const row_count = static_cast<size_t>(map_.rows());
+    size_t const col_count = static_cast<size_t>(map_.cols());
+    double discrete_movement_x=(max_x_-min_x_)/(map_side_length_x_-1);
+    double discrete_movement_y=(max_y_-min_y_)/(map_side_length_y_-1);
+
+
+    std::ofstream output_file("map_data.dat");
+    if (output_file.is_open()){
+        for (size_t row_index=0;row_index<row_count;row_index++){
+            for (size_t col_index=0;col_index<col_count;col_index++){
+                output_file << min_x_+col_index*discrete_movement_x <<" "<< min_y_+row_index*discrete_movement_y <<" "<< map_(row_index,col_index) << "\n";
+            }
+        }
+        
+        output_file.close();
+    }
+    if (output_file.is_open()){
+        std::cout << "File is unexpectedly still open\n";
+    }
+    //Using Gnuplot
+    FILE *gnuplot_pipe = popen("gnuplot -persist", "w");
+
+    if (gnuplot_pipe){
+        //Formatting
+        fprintf(gnuplot_pipe, "set view map\n");
+        fprintf(gnuplot_pipe, "set title 'Reward Map' font 'Times,16'\n");
+        fprintf(gnuplot_pipe, "set xrange [%f:%f]\n",min_x_,max_x_);
+        fprintf(gnuplot_pipe, "set yrange [%f:%f]\n",min_y_,max_y_);
+        fprintf(gnuplot_pipe, "set cblabel 'Reward Function' font 'Times,14' offset 1\n");
+        fprintf(gnuplot_pipe, "set tics font 'Times,14'\n");
+
+        fprintf(gnuplot_pipe, "set palette defined (%f 'white', %f 'forest-green')\n",reward_range_min_,reward_range_max_);
+
+
+        //The input_sorted_site_list should list the sites in the order to visit them
+
+        if (input_sorted_site_list.size()>1){
+            double next_site_x_coord=input_sorted_site_list.at(0).coordinates.first;
+            double next_site_y_coord=input_sorted_site_list.at(0).coordinates.second;
+            fprintf(gnuplot_pipe, "set arrow from %f,%f to %f,%f,1 filled front\n",starting_position_.first,starting_position_.second,next_site_x_coord,next_site_y_coord);
+            for (int arrow_ind=1;arrow_ind<input_sorted_site_list.size();arrow_ind++){
+                double previous_site_x_coord=input_sorted_site_list.at(arrow_ind-1).coordinates.first;
+                double previous_site_y_coord=input_sorted_site_list.at(arrow_ind-1).coordinates.second;
+                next_site_x_coord=input_sorted_site_list.at(arrow_ind).coordinates.first;
+                next_site_y_coord=input_sorted_site_list.at(arrow_ind).coordinates.second;
+                fprintf(gnuplot_pipe, "set arrow from %f,%f to %f,%f,%d filled front\n",previous_site_x_coord,previous_site_y_coord,next_site_x_coord,next_site_y_coord,arrow_ind);
+            }
+        }
+
+        fprintf(gnuplot_pipe, "plot 'map_data.dat' using 1:2:3 with image\n");
+        fprintf(gnuplot_pipe, "exit \n");
+        pclose(gnuplot_pipe);
+
+    }
+
+}
+
+
+void RandomRewardMap::plot_NN_total_distance_swept_distance_weight(double weight_increment,size_t num_weight_increments){
+
+    //Using Gnuplot
+    FILE *gnuplot_pipe = popen("gnuplot -persist", "w");
+
+    if (gnuplot_pipe){
+        //Formatting
+        fprintf(gnuplot_pipe, "set view map\n");
+        fprintf(gnuplot_pipe, "set title 'Total Distance' font 'Times,16'\n");
+        fprintf(gnuplot_pipe, "set xlabel 'Distance Weight' font 'Times,16'\n");
+        fprintf(gnuplot_pipe, "set logscale x 10\n");
+
+
+        fprintf(gnuplot_pipe, "plot '-' with lines notitle\n");
+        for (size_t index=0;index<num_weight_increments;index++){
+            double distance_weight=weight_increment*index;
+            std::pair<std::vector<site_obj>,double> output_pair=generate_paths_distance_weighted_NN(distance_weight);
+            double total_distance=output_pair.second;
+
+            fprintf(gnuplot_pipe, "%f %f\n",distance_weight,total_distance);
+        }
+        fprintf(gnuplot_pipe, "e \n");
+
+        fprintf(gnuplot_pipe, "exit \n");
+        pclose(gnuplot_pipe);
+    }
+
+}

--- a/src/manual_map_demo.cpp
+++ b/src/manual_map_demo.cpp
@@ -6,7 +6,7 @@ int main(){
 
     ManualRewardMap manual_reward_map;
 
-    //site parameters can be entered manually or randomly generated. 
+    //Site parameters can be entered manually or randomly generated. 
     //Demonstrations of workflows with manually-entered site parameters:
 
     //Explicitly creating site objects:
@@ -51,7 +51,7 @@ int main(){
     std::uniform_real_distribution<> site_y_distribution(sites_y_lower_bound,sites_y_upper_bound);
     std::uniform_real_distribution<> site_reward_val_distribution(sites_reward_val_lower_bound,sites_reward_val_upper_bound);
 
-    //now one can still explicitly create and add site objects:
+    //Now one can still explicitly create and add site objects:
 
 
     std::pair<double,double> site_5_coords;
@@ -77,14 +77,14 @@ int main(){
     manual_reward_map.add_site(manual_site_5);
     manual_reward_map.add_site(manual_site_6);
 
-    //or add the sites directly via generated values
+    //Or add the sites directly via generated values
     manual_reward_map.add_site(site_x_distribution(engine),site_y_distribution(engine),site_reward_val_distribution(engine));
     manual_reward_map.add_site(site_x_distribution(engine),site_y_distribution(engine),site_reward_val_distribution(engine));
 
-    //set the starting point of the path
+    //Set the starting point of the path
     std::pair<double,double> starting_position={0,0};
 
-    //set map parameters as desired
+    //Set map parameters as desired
     manual_reward_map.map_side_length_x_=51;
     manual_reward_map.map_side_length_y_=51;
     manual_reward_map.max_x_=1;
@@ -99,28 +99,28 @@ int main(){
     // manual_reward_map.draw_map(); //uncomment to draw map without paths
 
 
-    std::pair<std::vector<site_obj>,double>  paths_and_distance_1=manual_reward_map.generate_paths_descending_priority();
-    std::vector<site_obj> paths_1=paths_and_distance_1.first;
-    double distance_1=paths_and_distance_1.second;
-    manual_reward_map.draw_map_with_paths(paths_1);
-    std::cout << "Total distance of descending priority method: " << distance_1 << "\n";
+    std::pair<std::vector<site_obj>,double>  paths_and_distance_descending_priority=manual_reward_map.generate_paths_descending_priority();
+    std::vector<site_obj> paths_descending_priority=paths_and_distance_descending_priority.first;
+    double distance_descending_priority=paths_and_distance_descending_priority.second;
+    manual_reward_map.draw_map_with_paths(paths_descending_priority);
+    std::cout << "Total distance of descending priority method: " << distance_descending_priority << "\n";
 
 
 
-    double distance_weight_2=1;
-    std::pair<std::vector<site_obj>,double>  paths_and_distance_3=manual_reward_map.generate_paths_distance_weighted_NN(distance_weight_2);
-    std::vector<site_obj> paths_3=paths_and_distance_3.first;
-    double distance_3=paths_and_distance_3.second;
-    manual_reward_map.draw_map_with_paths(paths_3);
-    std::cout << "Total distance of NN method with distance weight = " << distance_weight_2 << ": " << distance_3 << "\n";
+    double distance_weight_med=1;
+    std::pair<std::vector<site_obj>,double>  paths_and_distance_NN_midweight=manual_reward_map.generate_paths_distance_weighted_NN(distance_weight_med);
+    std::vector<site_obj> paths_NN_midweight=paths_and_distance_NN_midweight.first;
+    double distance_NN_midweight=paths_and_distance_NN_midweight.second;
+    manual_reward_map.draw_map_with_paths(paths_NN_midweight);
+    std::cout << "Total distance of NN method with distance weight = " << distance_weight_med << ": " << distance_NN_midweight << "\n";
 
 
-    double distance_weight_3=100;
-    std::pair<std::vector<site_obj>,double>  paths_and_distance_4=manual_reward_map.generate_paths_distance_weighted_NN(distance_weight_3);
-    std::vector<site_obj> paths_4=paths_and_distance_4.first;
-    double distance_4=paths_and_distance_4.second;
-    manual_reward_map.draw_map_with_paths(paths_4);
-    std::cout << "Total distance of NN method with distance weight = " << distance_weight_3 << ": " << distance_4 << "\n";
+    double distance_weight_high=100;
+    std::pair<std::vector<site_obj>,double>  paths_and_distance_NN_highweight=manual_reward_map.generate_paths_distance_weighted_NN(distance_weight_high);
+    std::vector<site_obj> paths_NN_highweight=paths_and_distance_NN_highweight.first;
+    double distance_NN_highweight=paths_and_distance_NN_highweight.second;
+    manual_reward_map.draw_map_with_paths(paths_NN_highweight);
+    std::cout << "Total distance of NN method with distance weight = " << distance_weight_high << ": " << distance_NN_highweight << "\n";
 
 
     //Let's try sweeping this distance_weight and see if there's a noticeable minimum of the total distance

--- a/src/random_map_demo.cpp
+++ b/src/random_map_demo.cpp
@@ -1,0 +1,68 @@
+#include <iostream>
+#include "RandomRewardMap.h"
+
+
+int main(){
+
+    //First, set parameters of the random map
+    double map_side_length_x=21; //in pixels
+    double map_side_length_y=21;
+    double min_x=0;
+    double max_x=1;
+    double min_y=0;
+    double max_y=1;
+    double reward_range_min=0;
+    double reward_range_max=3;
+    std::pair<double,double> initial_position={0,0};
+    RandomRewardMap example_map(map_side_length_x,map_side_length_y,
+        min_x,max_x,
+        min_y,max_y,
+        reward_range_min,reward_range_max);
+
+    example_map.draw_map();
+
+    //Identify potentially interesting sites
+    int num_sites=5;
+    double site_reward_val_threshold=0.65;
+    example_map.identify_potential_sites(num_sites, site_reward_val_threshold);
+    //Since list_of_sites_ is already sorted in decreasing order of reward val, 
+    //can directly pass it here to get descending priority method path
+    std::vector<site_obj> list_of_identified_sites=example_map.get_list_of_sites();
+    example_map.draw_map_with_paths(list_of_identified_sites); 
+
+
+    site_reward_val_threshold=2.7;
+    //When no num_sites is passed to identify_potential_sites, it includes all sites whose reward vals meet or exceed the threshold
+    example_map.identify_potential_sites(site_reward_val_threshold);
+
+    std::vector<site_obj> new_list_of_identified_sites=example_map.get_list_of_sites();
+    example_map.draw_map_with_paths(new_list_of_identified_sites); 
+    double descending_priority_distance=calculate_total_distance_from_sequence(example_map.starting_position_,new_list_of_identified_sites);
+    std::cout << "Total distance of descending priority method: " << descending_priority_distance<< "\n";
+
+    //Now I'll demonstrate paths using a nearest-neighbor method with varying distance weight
+
+
+    double distance_weight_1=0.1;
+    std::pair<std::vector<site_obj>,double>  NN_paths_and_distance_1=example_map.generate_paths_distance_weighted_NN(distance_weight_1);
+    std::vector<site_obj> NN_paths_1=NN_paths_and_distance_1.first;
+    double NN_distance_1=NN_paths_and_distance_1.second;
+    example_map.draw_map_with_paths(NN_paths_1);
+    std::cout << "Total distance of NN method with distance weight = " << distance_weight_1 << ": " << NN_distance_1 << "\n";
+    
+
+    double distance_weight_2=100;
+    std::pair<std::vector<site_obj>,double>  NN_paths_and_distance_2=example_map.generate_paths_distance_weighted_NN(distance_weight_2);
+    std::vector<site_obj> NN_paths_2=NN_paths_and_distance_2.first;
+    double NN_distance_2=NN_paths_and_distance_2.second;
+    example_map.draw_map_with_paths(NN_paths_2);
+    std::cout << "Total distance of NN method with distance weight = " << distance_weight_2 << ": " << NN_distance_2 << "\n";
+
+    //Let's try sweeping this distance_weight and see if there's a noticeable minimum of the total distance
+    double weight_increment=0.001;
+    size_t num_weight_increments=10000;
+    example_map.plot_NN_total_distance_swept_distance_weight(weight_increment,num_weight_increments);
+    
+
+    return 0;
+}

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -31,6 +31,7 @@ double calculate_total_distance_from_sequence(std::pair<double,double> input_sta
     for (size_t site_ind=1;site_ind<input_site_sequence.size();site_ind++){
         calculated_distance=distance(current_position,input_site_sequence.at(site_ind).coordinates);
         total_distance+=calculated_distance;
+        current_position=input_site_sequence.at(site_ind).coordinates;
     }
 
     return total_distance;


### PR DESCRIPTION
# Context
I wanted to add the ability to randomly generate a reward value map and then add the capability to process one of these maps to identify potential sites of interest based on desired numbers of sites or reward value thresholds. I also found and fixed some bugs along the way.

# Changes
Added RandomRewardMap class for generating random reward maps (instead of manually adding sites of interest before pathing) as well as functionality for identifying potential sites of interest in these maps. This class also has support for generating paths (sequences of sites) per the descending-priority method and the distance-weighted nearest-neighbor methods.

Added sample workflow for this random reward map class

Also fixed bug in distance calculations where current position wasn't being updated Moved site_obj definition to utils.h

Added guard to utils.h

Added equality operator definition to site_obj for debugging purposes 

Renamed core.cpp to manual_map_demo.cpp to make its purpose more clear, cleaned up some of its variable names