### PR TITLE
Improving titles of generated plots, moving add_site implementations in manual map class out of header file

### DIFF
--- a/include/ManualRewardMap.h
+++ b/include/ManualRewardMap.h
@@ -34,61 +34,9 @@ class ManualRewardMap
 
         }
     
-        void add_site(site_obj input_site){
-            double site_x=input_site.coordinates.first;
-            double site_y=input_site.coordinates.second;
-            if (site_x<min_site_x_coord_){
-                min_site_x_coord_=site_x;
-            }
+        void add_site(site_obj input_site);
 
-            if (site_x>max_site_x_coord_){
-                max_site_x_coord_=site_x;
-            }
-
-            if (site_y<min_site_y_coord_){
-                min_site_y_coord_=site_y;
-            }
-
-            if (site_y>max_site_y_coord_){
-                max_site_y_coord_=site_y;
-            }
-            if (input_site.reward_val>max_reward_val_){
-                max_reward_val_=input_site.reward_val;
-            }
-
-            list_of_sites_.push_back(input_site);
-        }
-
-        void add_site(double x_coord, double y_coord, double reward_val){
-            //overloading to allow direct addition of a site through its coordinates and reward val
-
-            if (x_coord<min_site_x_coord_){
-                min_site_x_coord_=x_coord;
-            }
-
-            if (x_coord>max_site_x_coord_){
-                max_site_x_coord_=x_coord;
-            }
-
-            if (y_coord<min_site_y_coord_){
-                min_site_y_coord_=y_coord;
-            }
-
-            if (y_coord>max_site_y_coord_){
-                max_site_y_coord_=y_coord;
-            }
-            if (reward_val>max_reward_val_){
-                max_reward_val_=reward_val;
-            }
-            site_obj tmp_site;
-            std::pair<double,double> tmp_coord_pair;
-            tmp_coord_pair.first=x_coord;
-            tmp_coord_pair.second=y_coord;
-
-            tmp_site.coordinates = tmp_coord_pair;
-            tmp_site.reward_val=reward_val;
-            list_of_sites_.push_back(tmp_site);
-        }
+        void add_site(double x_coord, double y_coord, double reward_val); //overloading to allow direct addition of a site through its coordinates and reward val
 
         void set_initial_position(std::pair<double,double> input_position){
             starting_position_=input_position;
@@ -106,7 +54,9 @@ class ManualRewardMap
 
         void draw_map();
 
-        void draw_map_with_paths(const std::vector<site_obj>);
+        void draw_map_with_paths(const std::vector<site_obj>, std::string input_path_type="", double associated_distance_weight=0);
+        //Current options for input_path_type: "DescendingPriority" if the path being plotted was generated with the descending priority method, or 
+        //"Weighted_NN" if the path being plotted was generated with the distance-weighted nearest-neighbor method. If this is the case, pass the associated distance weight as the third argument.
 
         std::pair<std::vector<site_obj>,double>  generate_paths_descending_priority();
 

--- a/include/RandomRewardMap.h
+++ b/include/RandomRewardMap.h
@@ -68,7 +68,10 @@ class RandomRewardMap
 
         void draw_map();
 
-        void draw_map_with_paths(const std::vector<site_obj>);
+
+        void draw_map_with_paths(const std::vector<site_obj>, std::string input_path_type="", double associated_distance_weight=0);
+        //Current options for input_path_type: "DescendingPriority" if the path being plotted was generated with the descending priority method, or 
+        //"Weighted_NN" if the path being plotted was generated with the distance-weighted nearest-neighbor method. If this is the case, pass the associated distance weight as the third argument.
 
         std::pair<std::vector<site_obj>,double> generate_paths_distance_weighted_NN(const double distance_weight);
 

--- a/src/ManualRewardMap.cpp
+++ b/src/ManualRewardMap.cpp
@@ -3,6 +3,67 @@
 #include "ManualRewardMap.h"
 #include "utils.h"
 
+
+
+void ManualRewardMap::add_site(site_obj input_site){
+    double site_x=input_site.coordinates.first;
+    double site_y=input_site.coordinates.second;
+    if (site_x<min_site_x_coord_){
+        min_site_x_coord_=site_x;
+    }
+
+    if (site_x>max_site_x_coord_){
+        max_site_x_coord_=site_x;
+    }
+
+    if (site_y<min_site_y_coord_){
+        min_site_y_coord_=site_y;
+    }
+
+    if (site_y>max_site_y_coord_){
+        max_site_y_coord_=site_y;
+    }
+    if (input_site.reward_val>max_reward_val_){
+        max_reward_val_=input_site.reward_val;
+    }
+
+    list_of_sites_.push_back(input_site);
+}
+
+void ManualRewardMap::add_site(double x_coord, double y_coord, double reward_val){
+    //overloading to allow direct addition of a site through its coordinates and reward val
+
+    if (x_coord<min_site_x_coord_){
+        min_site_x_coord_=x_coord;
+    }
+
+    if (x_coord>max_site_x_coord_){
+        max_site_x_coord_=x_coord;
+    }
+
+    if (y_coord<min_site_y_coord_){
+        min_site_y_coord_=y_coord;
+    }
+
+    if (y_coord>max_site_y_coord_){
+        max_site_y_coord_=y_coord;
+    }
+    if (reward_val>max_reward_val_){
+        max_reward_val_=reward_val;
+    }
+    site_obj tmp_site;
+    std::pair<double,double> tmp_coord_pair;
+    tmp_coord_pair.first=x_coord;
+    tmp_coord_pair.second=y_coord;
+
+    tmp_site.coordinates = tmp_coord_pair;
+    tmp_site.reward_val=reward_val;
+    list_of_sites_.push_back(tmp_site);
+}
+
+
+
+
 void ManualRewardMap::generate_map(){
     map_.resize(map_side_length_y_,map_side_length_x_);
     map_.setZero(); //Fill background with zeros
@@ -143,7 +204,7 @@ void ManualRewardMap::draw_map(){
 
 
 
-void ManualRewardMap::draw_map_with_paths(const std::vector<site_obj> input_sorted_site_list){
+void ManualRewardMap::draw_map_with_paths(const std::vector<site_obj> input_sorted_site_list, std::string input_path_type, double associated_distance_weight){
 
     //First make the data file
     //Want to scale the x and y axes to be in coordinate form instead of indices of a matrix 
@@ -172,7 +233,16 @@ void ManualRewardMap::draw_map_with_paths(const std::vector<site_obj> input_sort
     if (gnuplot_pipe){
         //Formatting
         fprintf(gnuplot_pipe, "set view map\n");
-        fprintf(gnuplot_pipe, "set title 'Reward Map' font 'Arial,16'\n");
+
+        if (input_path_type=="DescendingPriority"){
+            fprintf(gnuplot_pipe, "set title 'Reward Map, Descending Priority Pathing' font 'Arial,16'\n");
+        }
+        else if (input_path_type=="Weighted_NN"){
+            fprintf(gnuplot_pipe, "set title 'Reward Map, Distance-Weighted NN Pathing with Weight=%0.3f' font 'Arial,16'\n",associated_distance_weight);
+        }
+        else {
+            fprintf(gnuplot_pipe, "set title 'Reward Map' font 'Arial,16'\n");
+        }        
         fprintf(gnuplot_pipe, "set xrange [%f:%f]\n",min_x_,max_x_);
         fprintf(gnuplot_pipe, "set yrange [%f:%f]\n",min_y_,max_y_);
         fprintf(gnuplot_pipe, "set cblabel 'Reward Function' font 'Arial,14' offset 1\n");

--- a/src/RandomRewardMap.cpp
+++ b/src/RandomRewardMap.cpp
@@ -111,7 +111,7 @@ void RandomRewardMap::draw_map(){
     FILE *gnuplot_pipe = popen("gnuplot -persist", "w");
 
     if (gnuplot_pipe){
-        //formatting
+        //Formatting
         fprintf(gnuplot_pipe, "set view map\n");
         fprintf(gnuplot_pipe, "set title 'Reward Map' font 'Times,16'\n");
         fprintf(gnuplot_pipe, "set xrange [%f:%f]\n",min_x_,max_x_);
@@ -166,7 +166,7 @@ std::pair<std::vector<site_obj>,double> RandomRewardMap::generate_paths_distance
 
 
 
-void RandomRewardMap::draw_map_with_paths(const std::vector<site_obj> input_sorted_site_list){
+void RandomRewardMap::draw_map_with_paths(const std::vector<site_obj> input_sorted_site_list,std::string input_path_type,double associated_distance_weight){
 
     //First make the data file
     //Want to scale the x and y axes to be in coordinate form instead of indices of a matrix 
@@ -195,7 +195,16 @@ void RandomRewardMap::draw_map_with_paths(const std::vector<site_obj> input_sort
     if (gnuplot_pipe){
         //Formatting
         fprintf(gnuplot_pipe, "set view map\n");
-        fprintf(gnuplot_pipe, "set title 'Reward Map' font 'Times,16'\n");
+
+        if (input_path_type=="DescendingPriority"){
+            fprintf(gnuplot_pipe, "set title 'Reward Map, Descending Priority Pathing' font 'Times,16'\n");
+        }
+        else if (input_path_type=="Weighted_NN"){
+            fprintf(gnuplot_pipe, "set title 'Reward Map, Distance-Weighted NN Pathing with Weight=%0.3f' font 'Times,16'\n",associated_distance_weight);
+        }
+        else {
+            fprintf(gnuplot_pipe, "set title 'Reward Map' font 'Times,16'\n");
+        }
         fprintf(gnuplot_pipe, "set xrange [%f:%f]\n",min_x_,max_x_);
         fprintf(gnuplot_pipe, "set yrange [%f:%f]\n",min_y_,max_y_);
         fprintf(gnuplot_pipe, "set cblabel 'Reward Function' font 'Times,14' offset 1\n");

--- a/src/manual_map_demo.cpp
+++ b/src/manual_map_demo.cpp
@@ -102,7 +102,7 @@ int main(){
     std::pair<std::vector<site_obj>,double>  paths_and_distance_descending_priority=manual_reward_map.generate_paths_descending_priority();
     std::vector<site_obj> paths_descending_priority=paths_and_distance_descending_priority.first;
     double distance_descending_priority=paths_and_distance_descending_priority.second;
-    manual_reward_map.draw_map_with_paths(paths_descending_priority);
+    manual_reward_map.draw_map_with_paths(paths_descending_priority,"DescendingPriority");
     std::cout << "Total distance of descending priority method: " << distance_descending_priority << "\n";
 
 
@@ -111,7 +111,7 @@ int main(){
     std::pair<std::vector<site_obj>,double>  paths_and_distance_NN_midweight=manual_reward_map.generate_paths_distance_weighted_NN(distance_weight_med);
     std::vector<site_obj> paths_NN_midweight=paths_and_distance_NN_midweight.first;
     double distance_NN_midweight=paths_and_distance_NN_midweight.second;
-    manual_reward_map.draw_map_with_paths(paths_NN_midweight);
+    manual_reward_map.draw_map_with_paths(paths_NN_midweight,"Weighted_NN",distance_weight_med);
     std::cout << "Total distance of NN method with distance weight = " << distance_weight_med << ": " << distance_NN_midweight << "\n";
 
 
@@ -119,7 +119,7 @@ int main(){
     std::pair<std::vector<site_obj>,double>  paths_and_distance_NN_highweight=manual_reward_map.generate_paths_distance_weighted_NN(distance_weight_high);
     std::vector<site_obj> paths_NN_highweight=paths_and_distance_NN_highweight.first;
     double distance_NN_highweight=paths_and_distance_NN_highweight.second;
-    manual_reward_map.draw_map_with_paths(paths_NN_highweight);
+    manual_reward_map.draw_map_with_paths(paths_NN_highweight,"Weighted_NN",distance_weight_high);
     std::cout << "Total distance of NN method with distance weight = " << distance_weight_high << ": " << distance_NN_highweight << "\n";
 
 

--- a/src/random_map_demo.cpp
+++ b/src/random_map_demo.cpp
@@ -19,16 +19,20 @@ int main(){
         min_y,max_y,
         reward_range_min,reward_range_max);
 
-    example_map.draw_map();
+    //uncomment this to see map drawn before any kind of pathing takes place
+    // example_map.draw_map();
 
     //Identify potentially interesting sites
-    int num_sites=5;
-    double site_reward_val_threshold=0.65;
-    example_map.identify_potential_sites(num_sites, site_reward_val_threshold);
-    //Since list_of_sites_ is already sorted in decreasing order of reward val, 
-    //can directly pass it here to get descending priority method path
-    std::vector<site_obj> list_of_identified_sites=example_map.get_list_of_sites();
-    example_map.draw_map_with_paths(list_of_identified_sites); 
+    double site_reward_val_threshold;
+
+    //uncomment this block to see example of limiting the number of identified sites
+    // int num_sites=5;
+    // site_reward_val_threshold=0.65;
+    // example_map.identify_potential_sites(num_sites, site_reward_val_threshold);
+    // //Since list_of_sites_ is already sorted in decreasing order of reward val, 
+    // //can directly pass it here to get descending priority method path
+    // std::vector<site_obj> list_of_identified_sites=example_map.get_list_of_sites();
+    // example_map.draw_map_with_paths(list_of_identified_sites,"DescendingPriority"); 
 
 
     site_reward_val_threshold=2.7;
@@ -36,7 +40,7 @@ int main(){
     example_map.identify_potential_sites(site_reward_val_threshold);
 
     std::vector<site_obj> new_list_of_identified_sites=example_map.get_list_of_sites();
-    example_map.draw_map_with_paths(new_list_of_identified_sites); 
+    example_map.draw_map_with_paths(new_list_of_identified_sites,"DescendingPriority"); 
     double descending_priority_distance=calculate_total_distance_from_sequence(example_map.starting_position_,new_list_of_identified_sites);
     std::cout << "Total distance of descending priority method: " << descending_priority_distance<< "\n";
 
@@ -47,7 +51,7 @@ int main(){
     std::pair<std::vector<site_obj>,double>  NN_paths_and_distance_1=example_map.generate_paths_distance_weighted_NN(distance_weight_1);
     std::vector<site_obj> NN_paths_1=NN_paths_and_distance_1.first;
     double NN_distance_1=NN_paths_and_distance_1.second;
-    example_map.draw_map_with_paths(NN_paths_1);
+    example_map.draw_map_with_paths(NN_paths_1,"Weighted_NN",distance_weight_1);
     std::cout << "Total distance of NN method with distance weight = " << distance_weight_1 << ": " << NN_distance_1 << "\n";
     
 
@@ -55,7 +59,7 @@ int main(){
     std::pair<std::vector<site_obj>,double>  NN_paths_and_distance_2=example_map.generate_paths_distance_weighted_NN(distance_weight_2);
     std::vector<site_obj> NN_paths_2=NN_paths_and_distance_2.first;
     double NN_distance_2=NN_paths_and_distance_2.second;
-    example_map.draw_map_with_paths(NN_paths_2);
+    example_map.draw_map_with_paths(NN_paths_2,"Weighted_NN",distance_weight_2);
     std::cout << "Total distance of NN method with distance weight = " << distance_weight_2 << ": " << NN_distance_2 << "\n";
 
     //Let's try sweeping this distance_weight and see if there's a noticeable minimum of the total distance


### PR DESCRIPTION
# Context
Generated plot titles didn't previously indicate what type of pathing was used, or in the NN case, what distance weight was used. Also the manual map header file would be cleaner without the add_site methods implemented in it.

# Changes
Added arguments to function that plots the maps with paths to be able to include information about the path generation method in the generated plots

Also decluttered the output of the random map demo a little more (commented out some plot generations)

# Integration Tests
Needs to pass unit testing workflow
